### PR TITLE
add budget CRUD routes and input validation for expenses

### DIFF
--- a/back-end/server/app.js
+++ b/back-end/server/app.js
@@ -6,16 +6,44 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// ===== In-memory data =====
+
 let expenses = [];
 
-app.get("/api/expenses", (req,res) => {
+let budget = {
+    incomeSources: [],
+    fixedExpenses: [],
+    period: "Monthly"
+};
+
+// ===== Expense validation =====
+
+function validateExpense(body) {
+    if (!body.name || typeof body.name !== "string" || !body.name.trim()) {
+        return "Expense name is required.";
+    }
+    if (body.amount === undefined || body.amount === "") {
+        return "Expense amount is required.";
+    }
+    if (isNaN(Number(body.amount))) {
+        return "Expense amount must be a number.";
+    }
+    return null;
+}
+
+// ===== Expense routes =====
+
+app.get("/api/expenses", (req, res) => {
     res.json(expenses);
 });
 
-app.post("/api/expenses", (req,res) => {
+app.post("/api/expenses", (req, res) => {
+    const error = validateExpense(req.body);
+    if (error) return res.status(400).json({ error });
+
     const newExpense = {
         id: Date.now(),
-        name: req.body.name,
+        name: req.body.name.trim(),
         amount: req.body.amount,
         category: req.body.category || "",
         details: req.body.details || "",
@@ -25,32 +53,86 @@ app.post("/api/expenses", (req,res) => {
     res.status(201).json(newExpense);
 });
 
-app.delete("/api/expenses/:id", (req,res) => {
-    const id = Number(req.params.id);
-    expenses = expenses.filter((expense) => expense.id !== id);
-    res.json({message:"Expense deleted"});
-});
-
-app.delete("/api/categories/:categoryName", (req,res) => {
-    const {categoryName} = req.params;
-    expenses = expenses.filter((expense) => expense.category !== categoryName);
-    res.json({message:"Category deleted"});
-});
-
 app.put("/api/expenses/:id", (req, res) => {
     const id = Number(req.params.id);
+    const exists = expenses.find(e => e.id === id);
+    if (!exists) return res.status(404).json({ error: "Expense not found." });
 
-    expenses = expenses.map((expense) => {
-        return expense.id === id ? {...expense, ...req.body} : expense
-    });
-    const updatedExpense = expenses.find((expense) => expense.id === id);
-    res.json(updatedExpense);
-})
+    if (req.body.amount !== undefined && isNaN(Number(req.body.amount))) {
+        return res.status(400).json({ error: "Expense amount must be a number." });
+    }
+
+    expenses = expenses.map(e => e.id === id ? { ...e, ...req.body } : e);
+    const updated = expenses.find(e => e.id === id);
+    res.json(updated);
+});
+
+app.delete("/api/expenses/:id", (req, res) => {
+    const id = Number(req.params.id);
+    expenses = expenses.filter(e => e.id !== id);
+    res.json({ message: "Expense deleted" });
+});
+
+app.delete("/api/categories/:categoryName", (req, res) => {
+    const { categoryName } = req.params;
+    expenses = expenses.filter(e => e.category !== categoryName);
+    res.json({ message: "Category deleted" });
+});
+
+// ===== Budget validation =====
+
+function validateBudget(body) {
+    if (body.incomeSources !== undefined && !Array.isArray(body.incomeSources)) {
+        return "incomeSources must be an array.";
+    }
+    if (body.fixedExpenses !== undefined && !Array.isArray(body.fixedExpenses)) {
+        return "fixedExpenses must be an array.";
+    }
+    const validPeriods = ["Monthly", "Weekly", "Yearly"];
+    if (body.period !== undefined && !validPeriods.includes(body.period)) {
+        return `period must be one of: ${validPeriods.join(", ")}.`;
+    }
+    return null;
+}
+
+// ===== Budget routes =====
+
+app.get("/api/budget", (req, res) => {
+    res.json(budget);
+});
+
+app.post("/api/budget", (req, res) => {
+    const error = validateBudget(req.body);
+    if (error) return res.status(400).json({ error });
+
+    budget = {
+        incomeSources: req.body.incomeSources || [],
+        fixedExpenses: req.body.fixedExpenses || [],
+        period: req.body.period || "Monthly"
+    };
+    res.status(201).json(budget);
+});
+
+app.put("/api/budget", (req, res) => {
+    const error = validateBudget(req.body);
+    if (error) return res.status(400).json({ error });
+
+    if (req.body.incomeSources !== undefined) budget.incomeSources = req.body.incomeSources;
+    if (req.body.fixedExpenses !== undefined) budget.fixedExpenses = req.body.fixedExpenses;
+    if (req.body.period !== undefined) budget.period = req.body.period;
+
+    res.json(budget);
+});
+
+app.delete("/api/budget", (req, res) => {
+    budget = { incomeSources: [], fixedExpenses: [], period: "Monthly" };
+    res.json({ message: "Budget reset." });
+});
+
+// ===== Auth stub =====
 
 app.post("/api/logout", (req, res) => {
-    res.status(200).json({
-        message: "Logout successful"
-    });
+    res.status(200).json({ message: "Logout successful" });
 });
 
 export default app;

--- a/back-end/server/test/test.js
+++ b/back-end/server/test/test.js
@@ -5,88 +5,183 @@ import app from "../app.js";
 
 chai.use(chaiHttp);
 
-describe("Expense Tracker API", function () {
-    it("GET /api/expenses should return an array", async function() {
+// ===== Expense Tests =====
+
+describe("Expense API", function () {
+    it("GET /api/expenses should return an array", async function () {
         const res = await chai.request(app).get("/api/expenses");
         expect(res).to.have.status(200);
         expect(res.body).to.be.an("array");
     });
 
-    it("POST /api/expenses should create a new expense", async function() {
-        const newExpense = {
-            name:"Headphones",
-            amount:"250",
-            category:"Tech",
-            details:"Useful for studying sessions",
-            dateAdded:"4/2/2026"
-        }
+    it("POST /api/expenses should create a new expense", async function () {
         const res = await chai.request(app)
             .post("/api/expenses")
-            .send(newExpense);
+            .send({ name: "Headphones", amount: "250", category: "Tech", details: "Useful for studying", dateAdded: "4/2/2026" });
         expect(res).to.have.status(201);
         expect(res.body).to.have.property("id");
         expect(res.body.name).to.equal("Headphones");
         expect(res.body.amount).to.equal("250");
     });
 
-    it("PUT /api/expenses/:id should update an expense", async function() {
+    it("POST /api/expenses should return 400 if name is missing", async function () {
+        const res = await chai.request(app)
+            .post("/api/expenses")
+            .send({ amount: "10", category: "Food" });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("POST /api/expenses should return 400 if amount is missing", async function () {
+        const res = await chai.request(app)
+            .post("/api/expenses")
+            .send({ name: "Coffee", category: "Food" });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("POST /api/expenses should return 400 if amount is not a number", async function () {
+        const res = await chai.request(app)
+            .post("/api/expenses")
+            .send({ name: "Coffee", amount: "abc", category: "Food" });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("PUT /api/expenses/:id should update an expense", async function () {
         const createRes = await chai.request(app)
             .post("/api/expenses")
-            .send({
-                name:"Hat",
-                amount:"20",
-                category:"Outfit",
-                details:"Very stylish"
-            });
-            const expenseId = createRes.body.id;
-            const updateRes = await chai.request(app)
-                .put(`/api/expenses/${expenseId}`)
-                .send({
-                    name:"Cap",
-                    amount:"22",
-                    category:"Outfit",
-                    details:"Simple aesthetic"
-                });
+            .send({ name: "Hat", amount: "20", category: "Outfit", details: "Very stylish" });
+        const expenseId = createRes.body.id;
 
-
+        const updateRes = await chai.request(app)
+            .put(`/api/expenses/${expenseId}`)
+            .send({ name: "Cap", amount: "22", category: "Outfit", details: "Simple aesthetic" });
         expect(updateRes).to.have.status(200);
         expect(updateRes.body.name).to.equal("Cap");
         expect(updateRes.body.amount).to.equal("22");
     });
 
-    it("DELETE /api/expenses/:id should delete an expense", async function() {
+    it("PUT /api/expenses/:id should return 404 if expense does not exist", async function () {
+        const res = await chai.request(app)
+            .put("/api/expenses/999999999")
+            .send({ name: "Ghost" });
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("PUT /api/expenses/:id should return 400 if updated amount is not a number", async function () {
         const createRes = await chai.request(app)
             .post("/api/expenses")
-            .send({
-                name:"Toy",
-                amount:"40",
-                category:"",
-                details:"Fun to use"
-            });
-            const expenseId = createRes.body.id;
-            const deleteRes = await chai.request(app)
-                .delete(`/api/expenses/${expenseId}`)
+            .send({ name: "Shoes", amount: "80", category: "Clothing" });
+        const expenseId = createRes.body.id;
 
+        const res = await chai.request(app)
+            .put(`/api/expenses/${expenseId}`)
+            .send({ amount: "not-a-number" });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("DELETE /api/expenses/:id should delete an expense", async function () {
+        const createRes = await chai.request(app)
+            .post("/api/expenses")
+            .send({ name: "Toy", amount: "40", category: "", details: "Fun to use" });
+        const expenseId = createRes.body.id;
+
+        const deleteRes = await chai.request(app).delete(`/api/expenses/${expenseId}`);
         expect(deleteRes).to.have.status(200);
         expect(deleteRes.body).to.have.property("message");
     });
 
-
-    it("DELETE /api/categories/:categoryName should delete a category", async function() {
+    it("DELETE /api/categories/:categoryName should delete all expenses in a category", async function () {
         await chai.request(app)
             .post("/api/expenses")
-            .send({
-                name:"Cake",
-                amount:"35",
-                category:"Dessert",
-                details:"Yummy"
-            });
+            .send({ name: "Cake", amount: "35", category: "Dessert", details: "Yummy" });
         const res = await chai.request(app).delete("/api/categories/Dessert");
         expect(res).to.have.status(200);
         expect(res.body).to.have.property("message");
     });
+});
 
-    it("POST /api/logout should logout successfully", async function() {
+// ===== Budget Tests =====
+
+describe("Budget API", function () {
+    it("GET /api/budget should return the budget object", async function () {
+        const res = await chai.request(app).get("/api/budget");
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property("incomeSources");
+        expect(res.body).to.have.property("fixedExpenses");
+        expect(res.body).to.have.property("period");
+    });
+
+    it("POST /api/budget should create a budget", async function () {
+        const res = await chai.request(app)
+            .post("/api/budget")
+            .send({
+                incomeSources: [{ name: "Job", amount: "500" }],
+                fixedExpenses: [{ name: "Rent", amount: "300" }],
+                period: "Monthly"
+            });
+        expect(res).to.have.status(201);
+        expect(res.body.incomeSources).to.deep.equal([{ name: "Job", amount: "500" }]);
+        expect(res.body.fixedExpenses).to.deep.equal([{ name: "Rent", amount: "300" }]);
+        expect(res.body.period).to.equal("Monthly");
+    });
+
+    it("POST /api/budget should return 400 for invalid period", async function () {
+        const res = await chai.request(app)
+            .post("/api/budget")
+            .send({ incomeSources: [], fixedExpenses: [], period: "Daily" });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("POST /api/budget should return 400 if incomeSources is not an array", async function () {
+        const res = await chai.request(app)
+            .post("/api/budget")
+            .send({ incomeSources: "not-an-array", fixedExpenses: [] });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("PUT /api/budget should update budget fields", async function () {
+        await chai.request(app)
+            .post("/api/budget")
+            .send({ incomeSources: [{ name: "Job", amount: "500" }], fixedExpenses: [], period: "Monthly" });
+
+        const res = await chai.request(app)
+            .put("/api/budget")
+            .send({ period: "Weekly" });
+        expect(res).to.have.status(200);
+        expect(res.body.period).to.equal("Weekly");
+        expect(res.body.incomeSources).to.deep.equal([{ name: "Job", amount: "500" }]);
+    });
+
+    it("PUT /api/budget should return 400 for invalid period", async function () {
+        const res = await chai.request(app)
+            .put("/api/budget")
+            .send({ period: "Hourly" });
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property("error");
+    });
+
+    it("DELETE /api/budget should reset the budget", async function () {
+        const res = await chai.request(app).delete("/api/budget");
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property("message");
+
+        const getRes = await chai.request(app).get("/api/budget");
+        expect(getRes.body.incomeSources).to.deep.equal([]);
+        expect(getRes.body.fixedExpenses).to.deep.equal([]);
+        expect(getRes.body.period).to.equal("Monthly");
+    });
+});
+
+// ===== Auth Tests =====
+
+describe("Auth API", function () {
+    it("POST /api/logout should logout successfully", async function () {
         const res = await chai.request(app).post("/api/logout");
         expect(res).to.have.status(200);
         expect(res.body).to.have.property("message");


### PR DESCRIPTION
- Added 4 budget routes: GET, POST, PUT, DELETE /api/budget with in-memory storage          
- Budget object matches what the frontend already expects (incomeSources, fixedExpenses, period)                                                                                     
- Added input validation for expenses — returns 400 if name is missing or amount is not a number                                                                                      
- Added 404 response when updating an expense that doesn't exist
- Expanded test suite from 6 to 18 passing tests covering all new routes and validation edge cases    