### PR TITLE
Add default accent color reset option in profile settings

### DIFF
--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -1543,3 +1543,25 @@ a {
 [data-theme="dark"] .land-stat-box {
   background: var(--card);
 }
+
+
+[data-theme="dark"] .expense-sort,
+[data-theme="dark"] .expense-search {
+  color: #f5f5f5;
+}
+
+[data-theme="dark"] .land-card-row .expense-item-cell,
+[data-theme="dark"] .expense-item-cell {
+  color: #f5f5f5;
+}
+
+[data-theme="dark"] .expense-category-name-row {
+  color: #f5f5f5;
+  background-color: #1e1e1e;
+  border: 1px solid #f5f5f5;
+}
+
+[data-theme="dark"] .expense-search-bar {
+  background-color: #ffffff;
+  color: #111;
+}

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -25,7 +25,7 @@ const PRESET_CATEGORIES = [
     "School / Education", "Bills", "Clothing", "Health"
 ]
 
-function AppContent({ expenses, setExpenses, pendingExpense, setPendingExpense, deleteExpense, deleteCategory, renameCategory, budget, setBudget, pastCategories, currencySymbol, setCurrencySymbol }) {
+function AppContent({ expenses, setExpenses, pendingExpense, setPendingExpense, deleteExpense, deleteCategory, renameCategory, budget, setBudget, pastCategories, currencySymbol, setCurrencySymbol, setAccentColor, resetAccentColor }) {
   const location = useLocation()
   const showNav = !NO_NAV_PAGES.includes(location.pathname)
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= 768)
@@ -73,7 +73,7 @@ function AppContent({ expenses, setExpenses, pendingExpense, setPendingExpense, 
           <Route path="/budget" element={<Budget budget={budget} expenses={expenses} currencySymbol={currencySymbol} />} />
           <Route path="/budget/create" element={<CreateBudget key={JSON.stringify(budget)} budget={budget} setBudget={setBudget} />} />
           <Route path="/budget/report" element={<BudgetReport budget={budget} expenses={expenses} currencySymbol={currencySymbol} />} />
-          <Route path="/profile" element={<Profile setCurrencySymbol={setCurrencySymbol} />} />
+          <Route path="/profile" element={<Profile setCurrencySymbol={setCurrencySymbol} setAccentColor={setAccentColor} resetAccentColor={resetAccentColor} />} />
           <Route path="/policies" element={<Policies />} />
         </Routes>
       </main>
@@ -86,6 +86,10 @@ function App() {
   const [pendingExpense, setPendingExpense] = useState(null)
   const [budget, setBudget] = useState({ incomeSources: [], fixedExpenses: [], period: "Monthly" })
   const [currencySymbol, setCurrencySymbol] = useState("$")
+  const DEFAULT_ACCENT = "#169246"
+  const [accentColor, setAccentColor] = useState(() => {
+  return localStorage.getItem("accentColor") || DEFAULT_ACCENT
+  })
 
   const pastCategories = useMemo(() => {
     const seen = new Set()
@@ -158,6 +162,14 @@ function App() {
     }
     loadCurrency()
   }, [])
+
+  useEffect(() => {
+  document.documentElement.style.setProperty("--accent", accentColor)
+  localStorage.setItem("accentColor", accentColor)}, [accentColor])
+
+  const resetAccentColor = () => {
+  setAccentColor(DEFAULT_ACCENT)
+  }
 
   async function deleteExpense(id) {
     const confirmed = window.confirm("Delete this expense?")
@@ -232,6 +244,8 @@ function App() {
         pastCategories={pastCategories}
         currencySymbol={currencySymbol}
         setCurrencySymbol={setCurrencySymbol}
+        setAccentColor={setAccentColor}
+        resetAccentColor={resetAccentColor}
       />
     </BrowserRouter>
   )

--- a/front-end/src/pages/Profile.jsx
+++ b/front-end/src/pages/Profile.jsx
@@ -55,7 +55,7 @@ const CURRENCIES = [
     { code: "ETB", symbol: "Br", name: "Ethiopian Birr" },
 ];
 
-function Profile({ setCurrencySymbol }) {
+function Profile({ setCurrencySymbol, resetAccentColor }) {
     const navigate = useNavigate()
     const [profile, setProfile] = useState({
         name: localStorage.getItem("userName") || "User",
@@ -113,6 +113,10 @@ function Profile({ setCurrencySymbol }) {
     localStorage.setItem("color", color)
 }, [theme, color])
 
+    function handleDefaultAccentColor() {
+        setColor("#169246")
+        if (resetAccentColor) resetAccentColor()
+    }
 
     async function handleSaveCurrency() {
         const token = localStorage.getItem("authToken")
@@ -236,16 +240,18 @@ function Profile({ setCurrencySymbol }) {
                     </select>
                 </div>
 
-                <div style={{ padding: "0 1.5rem" }}>
+                <div style={{ padding: "0 1.5rem", display: "flex", alignItems: "center", gap: "10px", flexWrap: "wrap" }}>
                     <label>Accent Color:</label>
                     <input
                         type="color"
                         value={color}
                         onChange={(e) => setColor(e.target.value)}
-                        style={{ marginLeft: "10px" }}
                     />
+                    <button className="btn-plain" onClick={handleDefaultAccentColor}>
+                        Default
+                    </button>
                 </div>
-            </div>
+                            </div>
 
 
             {/* Password Change */}


### PR DESCRIPTION
Added a default button to reset the accent color in profile settings.

Users can change the accent color and reset it back to the original green. The color is saved so it stays after refresh.